### PR TITLE
add gems option for jekyll 3.x.x

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ markdown: kramdown
 paginate: 5 # pagination based on number of posts
 paginate_path: "page/:num"
 highlighter: pygments
+gems: [jekyll-paginate]
 
 # comments
 disqus: # add disqus shortname here


### PR DESCRIPTION
I run this template in localhost with `jekyll 3.0.0`.
This message appeared. 

> % jekyll server 
> Configuration file: /Users/nzw/paper/_config.yml
>        Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `gems: [jekyll-paginate]` in your configuration file.
>             Source: /Users/nzw/paper
>        Destination: /Users/nzw/paper/_site
>  Incremental build: disabled. Enable with --incremental
>       Generating...
>                     done in 0.286 seconds.
>        Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `gems: [jekyll-paginate]` in your configuration file.
>  Auto-regeneration: enabled for '/Users/nzw/paper'
> Configuration file: /Users/nzw/paper/_config.yml
>     Server address: http://127.0.0.1:4000//
>   Server running... press ctrl-c to stop.

So, I add gems: `gems: [jekyll-paginate]` in `_config.yml` 

And,  this PR behaves properly with `Jekyll 2.5.3`

thanks.
