### PR TITLE
fix the bug: button events on touch device

### DIFF
--- a/categories.html
+++ b/categories.html
@@ -19,7 +19,7 @@ icon: folder
         {% for node in pages_list %}
           {% if node.title != null %}
             {% if group == null or group == node.group %}
-              <a class="mdl-button mdl-js-button mdl-js-ripple-effect" href="{{ node.url | replace_first: '/', '' | prepend: site.baseurl | prepend: site.url }}">
+              <a class="mdl-button mdl-js-button" href="{{ node.url | replace_first: '/', '' | prepend: site.baseurl | prepend: site.url }}">
                 <span class="button-header">
                   {{node.title}}
                 </span>


### PR DESCRIPTION
Hi, I make my github blog through this repository.

But, when I clicked button for posts in categories on my tablet(Ipad pro 10.5), the button event didn't work.

After deleting this class, I could solve this problem.

Thank you for sharing great works.